### PR TITLE
feat: add Google Calendar integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,10 @@ STATE_PATH=state
 CLAUDE_MODEL=claude-sonnet-4-20250514
 # Set to "true" to use interactive tmux mode (for debugging)
 EXECUTIVE_INTERACTIVE=false
+
+# Google Calendar Integration (optional)
+# Path to your Google service account JSON credentials file
+GOOGLE_CALENDAR_CREDENTIALS_FILE=/path/to/service-account.json
+# Calendar ID to access (usually the email address of the calendar)
+# For your primary calendar, this is your Gmail address
+GOOGLE_CALENDAR_ID=your-email@gmail.com

--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,11 @@ CLAUDE_MODEL=claude-sonnet-4-20250514
 EXECUTIVE_INTERACTIVE=false
 
 # Google Calendar Integration (optional)
-# Service account credentials - either inline JSON or file path
-# Inline JSON (preferred - paste entire service account JSON here):
-GOOGLE_CALENDAR_CREDENTIALS={"type":"service_account","project_id":"...","private_key":"...","client_email":"..."}
-# Or use a file path:
+# Service account credentials - either base64-encoded JSON or file path
+# Base64 encoded (preferred): encode your service account JSON with base64
+# Example: cat service-account.json | base64 -w0
+GOOGLE_CALENDAR_CREDENTIALS=eyJ0eXBlIjoic2VydmljZV9hY2NvdW50IiwicHJvamVjdF9pZCI6Ii4uLiIsInByaXZhdGVfa2V5IjoiLi4uIiwiY2xpZW50X2VtYWlsIjoiLi4uIn0=
+# Or use a file path (no encoding needed):
 # GOOGLE_CALENDAR_CREDENTIALS_FILE=/path/to/service-account.json
 
 # Calendar IDs to access (comma-separated, usually email addresses)

--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,13 @@ CLAUDE_MODEL=claude-sonnet-4-20250514
 EXECUTIVE_INTERACTIVE=false
 
 # Google Calendar Integration (optional)
-# Path to your Google service account JSON credentials file
-GOOGLE_CALENDAR_CREDENTIALS_FILE=/path/to/service-account.json
-# Calendar ID to access (usually the email address of the calendar)
+# Service account credentials - either inline JSON or file path
+# Inline JSON (preferred - paste entire service account JSON here):
+GOOGLE_CALENDAR_CREDENTIALS={"type":"service_account","project_id":"...","private_key":"...","client_email":"..."}
+# Or use a file path:
+# GOOGLE_CALENDAR_CREDENTIALS_FILE=/path/to/service-account.json
+
+# Calendar IDs to access (comma-separated, usually email addresses)
 # For your primary calendar, this is your Gmail address
-GOOGLE_CALENDAR_ID=your-email@gmail.com
+# You can list multiple calendars to aggregate events from all of them
+GOOGLE_CALENDAR_IDS=your-email@gmail.com,shared-calendar@group.calendar.google.com

--- a/cmd/bud-mcp/main.go
+++ b/cmd/bud-mcp/main.go
@@ -1338,12 +1338,14 @@ func main() {
 	}
 
 	// Google Calendar tools (only register if credentials are configured)
-	if os.Getenv("GOOGLE_CALENDAR_CREDENTIALS_FILE") != "" && os.Getenv("GOOGLE_CALENDAR_ID") != "" {
+	hasCalendarCreds := os.Getenv("GOOGLE_CALENDAR_CREDENTIALS") != "" || os.Getenv("GOOGLE_CALENDAR_CREDENTIALS_FILE") != ""
+	hasCalendarIDs := os.Getenv("GOOGLE_CALENDAR_IDS") != "" || os.Getenv("GOOGLE_CALENDAR_ID") != ""
+	if hasCalendarCreds && hasCalendarIDs {
 		calendarClient, err := calendar.NewClient()
 		if err != nil {
 			log.Printf("Warning: Failed to create Calendar client: %v", err)
 		} else {
-			log.Println("Google Calendar integration enabled")
+			log.Printf("Google Calendar integration enabled (%d calendars)", len(calendarClient.CalendarIDs()))
 
 			// Register calendar_today tool - get today's events
 			server.RegisterTool("calendar_today", func(ctx any, args map[string]any) (string, error) {
@@ -1620,7 +1622,7 @@ func main() {
 			})
 		}
 	} else {
-		log.Println("Google Calendar integration disabled (GOOGLE_CALENDAR_CREDENTIALS_FILE or GOOGLE_CALENDAR_ID not set)")
+		log.Println("Google Calendar integration disabled (credentials not configured)")
 	}
 
 	// State introspection tools

--- a/cmd/bud/main.go
+++ b/cmd/bud/main.go
@@ -267,13 +267,15 @@ func main() {
 
 	// Initialize calendar client (optional - only if credentials are configured)
 	var calendarClient *calendar.Client
-	if os.Getenv("GOOGLE_CALENDAR_CREDENTIALS_FILE") != "" && os.Getenv("GOOGLE_CALENDAR_ID") != "" {
+	hasCalendarCreds := os.Getenv("GOOGLE_CALENDAR_CREDENTIALS") != "" || os.Getenv("GOOGLE_CALENDAR_CREDENTIALS_FILE") != ""
+	hasCalendarIDs := os.Getenv("GOOGLE_CALENDAR_IDS") != "" || os.Getenv("GOOGLE_CALENDAR_ID") != ""
+	if hasCalendarCreds && hasCalendarIDs {
 		var err error
 		calendarClient, err = calendar.NewClient()
 		if err != nil {
 			log.Printf("Warning: failed to create calendar client: %v", err)
 		} else {
-			log.Println("[main] Google Calendar integration enabled")
+			log.Printf("[main] Google Calendar integration enabled (%d calendars)", len(calendarClient.CalendarIDs()))
 			reflexEngine.SetCalendarClient(calendarClient)
 		}
 	} else {

--- a/internal/integrations/calendar/client.go
+++ b/internal/integrations/calendar/client.go
@@ -54,7 +54,7 @@ type serviceAccountCredentials struct {
 // Config holds calendar client configuration
 type Config struct {
 	CredentialsFile string   // Path to service account JSON file (optional if CredentialsJSON is set)
-	CredentialsJSON string   // Inline JSON credentials (optional if CredentialsFile is set)
+	CredentialsJSON string   // Base64-encoded service account JSON (optional if CredentialsFile is set)
 	CalendarIDs     []string // Calendar IDs to access (usually email addresses)
 }
 
@@ -98,9 +98,12 @@ func NewClientWithConfig(cfg Config) (*Client, error) {
 	var data []byte
 	var err error
 
-	// Prefer inline JSON, fall back to file
+	// Prefer inline JSON (base64 encoded), fall back to file
 	if cfg.CredentialsJSON != "" {
-		data = []byte(cfg.CredentialsJSON)
+		data, err = base64.StdEncoding.DecodeString(cfg.CredentialsJSON)
+		if err != nil {
+			return nil, fmt.Errorf("decode base64 credentials: %w", err)
+		}
 	} else if cfg.CredentialsFile != "" {
 		data, err = os.ReadFile(cfg.CredentialsFile)
 		if err != nil {

--- a/internal/integrations/calendar/client.go
+++ b/internal/integrations/calendar/client.go
@@ -1,0 +1,699 @@
+package calendar
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	baseURL      = "https://www.googleapis.com/calendar/v3"
+	tokenURL     = "https://oauth2.googleapis.com/token"
+	tokenExpiry  = 55 * time.Minute // Refresh before 1 hour expiry
+)
+
+// Client is a Google Calendar API client using service account authentication
+type Client struct {
+	httpClient  *http.Client
+	calendarID  string
+	credentials *serviceAccountCredentials
+
+	// Token caching
+	mu          sync.RWMutex
+	accessToken string
+	tokenExpiry time.Time
+}
+
+// serviceAccountCredentials holds the service account JSON key
+type serviceAccountCredentials struct {
+	Type         string `json:"type"`
+	ProjectID    string `json:"project_id"`
+	PrivateKeyID string `json:"private_key_id"`
+	PrivateKey   string `json:"private_key"`
+	ClientEmail  string `json:"client_email"`
+	ClientID     string `json:"client_id"`
+	AuthURI      string `json:"auth_uri"`
+	TokenURI     string `json:"token_uri"`
+}
+
+// Config holds calendar client configuration
+type Config struct {
+	CredentialsFile string // Path to service account JSON file
+	CalendarID      string // Calendar ID to access (usually an email address)
+}
+
+// NewClient creates a new Google Calendar client from environment variables
+func NewClient() (*Client, error) {
+	credsFile := os.Getenv("GOOGLE_CALENDAR_CREDENTIALS_FILE")
+	if credsFile == "" {
+		return nil, fmt.Errorf("GOOGLE_CALENDAR_CREDENTIALS_FILE not set")
+	}
+
+	calendarID := os.Getenv("GOOGLE_CALENDAR_ID")
+	if calendarID == "" {
+		return nil, fmt.Errorf("GOOGLE_CALENDAR_ID not set")
+	}
+
+	return NewClientWithConfig(Config{
+		CredentialsFile: credsFile,
+		CalendarID:      calendarID,
+	})
+}
+
+// NewClientWithConfig creates a new client with explicit configuration
+func NewClientWithConfig(cfg Config) (*Client, error) {
+	// Read the service account credentials
+	data, err := os.ReadFile(cfg.CredentialsFile)
+	if err != nil {
+		return nil, fmt.Errorf("read credentials file: %w", err)
+	}
+
+	var creds serviceAccountCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("parse credentials: %w", err)
+	}
+
+	if creds.Type != "service_account" {
+		return nil, fmt.Errorf("credentials file must be a service account key (got %s)", creds.Type)
+	}
+
+	return &Client{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		calendarID:  cfg.CalendarID,
+		credentials: &creds,
+	}, nil
+}
+
+// getAccessToken returns a valid access token, refreshing if needed
+func (c *Client) getAccessToken(ctx context.Context) (string, error) {
+	c.mu.RLock()
+	if c.accessToken != "" && time.Now().Before(c.tokenExpiry) {
+		token := c.accessToken
+		c.mu.RUnlock()
+		return token, nil
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if c.accessToken != "" && time.Now().Before(c.tokenExpiry) {
+		return c.accessToken, nil
+	}
+
+	// Create JWT assertion
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":   c.credentials.ClientEmail,
+		"scope": "https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.events",
+		"aud":   tokenURL,
+		"iat":   now.Unix(),
+		"exp":   now.Add(time.Hour).Unix(),
+	}
+
+	jwt, err := c.signJWT(claims)
+	if err != nil {
+		return "", fmt.Errorf("sign JWT: %w", err)
+	}
+
+	// Exchange JWT for access token
+	data := url.Values{}
+	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
+	data.Set("assertion", jwt)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read token response: %w", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("token request failed (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		TokenType   string `json:"token_type"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("parse token response: %w", err)
+	}
+
+	c.accessToken = tokenResp.AccessToken
+	c.tokenExpiry = now.Add(tokenExpiry)
+
+	return c.accessToken, nil
+}
+
+// signJWT creates a signed JWT assertion
+func (c *Client) signJWT(claims map[string]interface{}) (string, error) {
+	// Parse private key
+	block, _ := pem.Decode([]byte(c.credentials.PrivateKey))
+	if block == nil {
+		return "", fmt.Errorf("failed to parse PEM block")
+	}
+
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("parse private key: %w", err)
+	}
+
+	rsaKey, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		return "", fmt.Errorf("private key is not RSA")
+	}
+
+	// Create header
+	header := map[string]string{
+		"alg": "RS256",
+		"typ": "JWT",
+	}
+
+	headerJSON, _ := json.Marshal(header)
+	claimsJSON, _ := json.Marshal(claims)
+
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	claimsB64 := base64.RawURLEncoding.EncodeToString(claimsJSON)
+
+	signingInput := headerB64 + "." + claimsB64
+
+	// Sign
+	hash := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(nil, rsaKey, crypto.SHA256, hash[:])
+	if err != nil {
+		return "", fmt.Errorf("sign: %w", err)
+	}
+
+	signatureB64 := base64.RawURLEncoding.EncodeToString(signature)
+
+	return signingInput + "." + signatureB64, nil
+}
+
+// request makes an authenticated request to the Calendar API
+func (c *Client) request(ctx context.Context, method, path string, body interface{}) ([]byte, error) {
+	token, err := c.getAccessToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get access token: %w", err)
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, baseURL+path, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+			return nil, fmt.Errorf("calendar API error (%d): %s", errResp.Error.Code, errResp.Error.Message)
+		}
+		return nil, fmt.Errorf("calendar API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}
+
+// Event represents a calendar event
+type Event struct {
+	ID          string            `json:"id"`
+	Summary     string            `json:"summary"`
+	Description string            `json:"description,omitempty"`
+	Location    string            `json:"location,omitempty"`
+	Start       time.Time         `json:"start"`
+	End         time.Time         `json:"end"`
+	AllDay      bool              `json:"all_day"`
+	Status      string            `json:"status"` // confirmed, tentative, cancelled
+	Organizer   string            `json:"organizer,omitempty"`
+	Attendees   []Attendee        `json:"attendees,omitempty"`
+	HtmlLink    string            `json:"html_link,omitempty"`
+	MeetLink    string            `json:"meet_link,omitempty"`
+	Recurrence  []string          `json:"recurrence,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// Attendee represents an event attendee
+type Attendee struct {
+	Email          string `json:"email"`
+	DisplayName    string `json:"display_name,omitempty"`
+	ResponseStatus string `json:"response_status"` // needsAction, declined, tentative, accepted
+	Self           bool   `json:"self,omitempty"`
+	Organizer      bool   `json:"organizer,omitempty"`
+}
+
+// googleEvent represents the Google Calendar API event format
+type googleEvent struct {
+	ID           string           `json:"id"`
+	Summary      string           `json:"summary"`
+	Description  string           `json:"description,omitempty"`
+	Location     string           `json:"location,omitempty"`
+	Status       string           `json:"status"`
+	HtmlLink     string           `json:"htmlLink,omitempty"`
+	Recurrence   []string         `json:"recurrence,omitempty"`
+	Start        *googleDateTime  `json:"start,omitempty"`
+	End          *googleDateTime  `json:"end,omitempty"`
+	Organizer    *googlePerson    `json:"organizer,omitempty"`
+	Attendees    []googleAttendee `json:"attendees,omitempty"`
+	ConferenceData *conferenceData `json:"conferenceData,omitempty"`
+	ExtendedProperties *extendedProps `json:"extendedProperties,omitempty"`
+}
+
+type googleDateTime struct {
+	DateTime string `json:"dateTime,omitempty"`
+	Date     string `json:"date,omitempty"`
+	TimeZone string `json:"timeZone,omitempty"`
+}
+
+type googlePerson struct {
+	Email       string `json:"email"`
+	DisplayName string `json:"displayName,omitempty"`
+}
+
+type googleAttendee struct {
+	Email          string `json:"email"`
+	DisplayName    string `json:"displayName,omitempty"`
+	ResponseStatus string `json:"responseStatus,omitempty"`
+	Self           bool   `json:"self,omitempty"`
+	Organizer      bool   `json:"organizer,omitempty"`
+}
+
+type conferenceData struct {
+	EntryPoints []entryPoint `json:"entryPoints,omitempty"`
+}
+
+type entryPoint struct {
+	EntryPointType string `json:"entryPointType"`
+	URI            string `json:"uri"`
+}
+
+type extendedProps struct {
+	Private map[string]string `json:"private,omitempty"`
+}
+
+type eventsResponse struct {
+	Items []googleEvent `json:"items"`
+}
+
+// ListEventsParams for querying events
+type ListEventsParams struct {
+	TimeMin      time.Time // Start of time range (required)
+	TimeMax      time.Time // End of time range (required)
+	MaxResults   int       // Max events to return (default 100)
+	SingleEvents bool      // Expand recurring events (default true)
+	OrderBy      string    // "startTime" or "updated" (default "startTime")
+	Query        string    // Free text search
+}
+
+// ListEvents retrieves events in the specified time range
+func (c *Client) ListEvents(ctx context.Context, params ListEventsParams) ([]Event, error) {
+	if params.MaxResults == 0 {
+		params.MaxResults = 100
+	}
+	if params.OrderBy == "" {
+		params.OrderBy = "startTime"
+	}
+
+	queryParams := url.Values{}
+	queryParams.Set("timeMin", params.TimeMin.Format(time.RFC3339))
+	queryParams.Set("timeMax", params.TimeMax.Format(time.RFC3339))
+	queryParams.Set("maxResults", fmt.Sprintf("%d", params.MaxResults))
+	queryParams.Set("singleEvents", "true")
+	queryParams.Set("orderBy", params.OrderBy)
+	if params.Query != "" {
+		queryParams.Set("q", params.Query)
+	}
+
+	path := fmt.Sprintf("/calendars/%s/events?%s", url.PathEscape(c.calendarID), queryParams.Encode())
+	data, err := c.request(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp eventsResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse events response: %w", err)
+	}
+
+	events := make([]Event, 0, len(resp.Items))
+	for _, item := range resp.Items {
+		event, err := convertEvent(&item)
+		if err != nil {
+			continue // Skip malformed events
+		}
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+// GetEvent retrieves a specific event by ID
+func (c *Client) GetEvent(ctx context.Context, eventID string) (*Event, error) {
+	path := fmt.Sprintf("/calendars/%s/events/%s", url.PathEscape(c.calendarID), url.PathEscape(eventID))
+	data, err := c.request(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var item googleEvent
+	if err := json.Unmarshal(data, &item); err != nil {
+		return nil, fmt.Errorf("parse event: %w", err)
+	}
+
+	event, err := convertEvent(&item)
+	if err != nil {
+		return nil, err
+	}
+
+	return &event, nil
+}
+
+// GetUpcomingEvents retrieves events in the next duration
+func (c *Client) GetUpcomingEvents(ctx context.Context, duration time.Duration, maxResults int) ([]Event, error) {
+	now := time.Now()
+	return c.ListEvents(ctx, ListEventsParams{
+		TimeMin:    now,
+		TimeMax:    now.Add(duration),
+		MaxResults: maxResults,
+	})
+}
+
+// GetTodayEvents retrieves all events for today
+func (c *Client) GetTodayEvents(ctx context.Context) ([]Event, error) {
+	now := time.Now()
+	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	endOfDay := startOfDay.Add(24 * time.Hour)
+
+	return c.ListEvents(ctx, ListEventsParams{
+		TimeMin: startOfDay,
+		TimeMax: endOfDay,
+	})
+}
+
+// FreeBusyParams for checking availability
+type FreeBusyParams struct {
+	TimeMin time.Time
+	TimeMax time.Time
+}
+
+// BusyPeriod represents a period when the calendar is busy
+type BusyPeriod struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// FreeBusy checks availability for the calendar
+func (c *Client) FreeBusy(ctx context.Context, params FreeBusyParams) ([]BusyPeriod, error) {
+	reqBody := map[string]interface{}{
+		"timeMin": params.TimeMin.Format(time.RFC3339),
+		"timeMax": params.TimeMax.Format(time.RFC3339),
+		"items": []map[string]string{
+			{"id": c.calendarID},
+		},
+	}
+
+	data, err := c.request(ctx, "POST", "/freeBusy", reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		Calendars map[string]struct {
+			Busy []struct {
+				Start string `json:"start"`
+				End   string `json:"end"`
+			} `json:"busy"`
+		} `json:"calendars"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse freebusy response: %w", err)
+	}
+
+	calendar, ok := resp.Calendars[c.calendarID]
+	if !ok {
+		return nil, fmt.Errorf("calendar not found in response")
+	}
+
+	periods := make([]BusyPeriod, 0, len(calendar.Busy))
+	for _, busy := range calendar.Busy {
+		start, _ := time.Parse(time.RFC3339, busy.Start)
+		end, _ := time.Parse(time.RFC3339, busy.End)
+		periods = append(periods, BusyPeriod{
+			Start: start,
+			End:   end,
+		})
+	}
+
+	return periods, nil
+}
+
+// CreateEventParams for creating a new event
+type CreateEventParams struct {
+	Summary     string
+	Description string
+	Location    string
+	Start       time.Time
+	End         time.Time
+	AllDay      bool
+	Attendees   []string // Email addresses
+}
+
+// CreateEvent creates a new calendar event
+func (c *Client) CreateEvent(ctx context.Context, params CreateEventParams) (*Event, error) {
+	event := map[string]interface{}{
+		"summary":     params.Summary,
+		"description": params.Description,
+		"location":    params.Location,
+	}
+
+	if params.AllDay {
+		event["start"] = map[string]string{
+			"date": params.Start.Format("2006-01-02"),
+		}
+		event["end"] = map[string]string{
+			"date": params.End.Format("2006-01-02"),
+		}
+	} else {
+		event["start"] = map[string]string{
+			"dateTime": params.Start.Format(time.RFC3339),
+			"timeZone": params.Start.Location().String(),
+		}
+		event["end"] = map[string]string{
+			"dateTime": params.End.Format(time.RFC3339),
+			"timeZone": params.End.Location().String(),
+		}
+	}
+
+	if len(params.Attendees) > 0 {
+		attendees := make([]map[string]string, len(params.Attendees))
+		for i, email := range params.Attendees {
+			attendees[i] = map[string]string{"email": email}
+		}
+		event["attendees"] = attendees
+	}
+
+	path := fmt.Sprintf("/calendars/%s/events", url.PathEscape(c.calendarID))
+	data, err := c.request(ctx, "POST", path, event)
+	if err != nil {
+		return nil, err
+	}
+
+	var item googleEvent
+	if err := json.Unmarshal(data, &item); err != nil {
+		return nil, fmt.Errorf("parse created event: %w", err)
+	}
+
+	result, err := convertEvent(&item)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// CalendarID returns the configured calendar ID
+func (c *Client) CalendarID() string {
+	return c.calendarID
+}
+
+// convertEvent converts a Google Calendar event to our Event type
+func convertEvent(item *googleEvent) (Event, error) {
+	event := Event{
+		ID:          item.ID,
+		Summary:     item.Summary,
+		Description: item.Description,
+		Location:    item.Location,
+		Status:      item.Status,
+		HtmlLink:    item.HtmlLink,
+		Recurrence:  item.Recurrence,
+	}
+
+	// Parse start time
+	if item.Start != nil {
+		if item.Start.DateTime != "" {
+			t, err := time.Parse(time.RFC3339, item.Start.DateTime)
+			if err != nil {
+				return Event{}, fmt.Errorf("parse start time: %w", err)
+			}
+			event.Start = t
+		} else if item.Start.Date != "" {
+			t, err := time.Parse("2006-01-02", item.Start.Date)
+			if err != nil {
+				return Event{}, fmt.Errorf("parse start date: %w", err)
+			}
+			event.Start = t
+			event.AllDay = true
+		}
+	}
+
+	// Parse end time
+	if item.End != nil {
+		if item.End.DateTime != "" {
+			t, err := time.Parse(time.RFC3339, item.End.DateTime)
+			if err != nil {
+				return Event{}, fmt.Errorf("parse end time: %w", err)
+			}
+			event.End = t
+		} else if item.End.Date != "" {
+			t, err := time.Parse("2006-01-02", item.End.Date)
+			if err != nil {
+				return Event{}, fmt.Errorf("parse end date: %w", err)
+			}
+			event.End = t
+		}
+	}
+
+	// Extract organizer
+	if item.Organizer != nil {
+		if item.Organizer.DisplayName != "" {
+			event.Organizer = item.Organizer.DisplayName
+		} else {
+			event.Organizer = item.Organizer.Email
+		}
+	}
+
+	// Extract attendees
+	if len(item.Attendees) > 0 {
+		event.Attendees = make([]Attendee, len(item.Attendees))
+		for i, a := range item.Attendees {
+			event.Attendees[i] = Attendee{
+				Email:          a.Email,
+				DisplayName:    a.DisplayName,
+				ResponseStatus: a.ResponseStatus,
+				Self:           a.Self,
+				Organizer:      a.Organizer,
+			}
+		}
+	}
+
+	// Extract Google Meet link
+	if item.ConferenceData != nil {
+		for _, entry := range item.ConferenceData.EntryPoints {
+			if entry.EntryPointType == "video" {
+				event.MeetLink = entry.URI
+				break
+			}
+		}
+	}
+
+	// Extract extended properties as metadata
+	if item.ExtendedProperties != nil && item.ExtendedProperties.Private != nil {
+		event.Metadata = item.ExtendedProperties.Private
+	}
+
+	return event, nil
+}
+
+// FormatEventSummary returns a human-readable summary of an event
+func (e *Event) FormatEventSummary() string {
+	timeStr := e.Start.Format("3:04 PM")
+	if e.AllDay {
+		timeStr = "All day"
+	}
+
+	summary := fmt.Sprintf("%s - %s", timeStr, e.Summary)
+	if e.Location != "" {
+		summary += fmt.Sprintf(" @ %s", e.Location)
+	}
+	if e.MeetLink != "" {
+		summary += " (has video call)"
+	}
+
+	return summary
+}
+
+// Duration returns the event duration
+func (e *Event) Duration() time.Duration {
+	return e.End.Sub(e.Start)
+}
+
+// IsHappeningSoon returns true if the event starts within the given duration
+func (e *Event) IsHappeningSoon(within time.Duration) bool {
+	return time.Until(e.Start) <= within && time.Until(e.Start) > 0
+}
+
+// IsHappeningNow returns true if the event is currently in progress
+func (e *Event) IsHappeningNow() bool {
+	now := time.Now()
+	return now.After(e.Start) && now.Before(e.End)
+}
+
+// ToJSON returns the event as a JSON string
+func (e *Event) ToJSON() string {
+	data, _ := json.MarshalIndent(e, "", "  ")
+	return string(data)
+}

--- a/internal/senses/calendar.go
+++ b/internal/senses/calendar.go
@@ -1,0 +1,418 @@
+package senses
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/vthunder/bud2/internal/integrations/calendar"
+	"github.com/vthunder/bud2/internal/memory"
+)
+
+// DefaultCalendarPollInterval is how often to check for upcoming events
+const DefaultCalendarPollInterval = 5 * time.Minute
+
+// DefaultMeetingReminderBefore is how far ahead to send meeting reminders
+const DefaultMeetingReminderBefore = 15 * time.Minute
+
+// CalendarSense monitors Google Calendar and produces percepts for events
+type CalendarSense struct {
+	client       *calendar.Client
+	inbox        *memory.Inbox
+	pollInterval time.Duration
+	reminderBefore time.Duration
+
+	// State tracking
+	mu              sync.RWMutex
+	lastPoll        time.Time
+	notifiedEvents  map[string]time.Time // eventID -> when we notified
+	lastDailyAgenda time.Time            // when we last sent daily agenda
+
+	// Control
+	stopChan chan struct{}
+	stopped  bool
+
+	// Callbacks
+	onError func(err error)
+}
+
+// CalendarConfig holds configuration for the calendar sense
+type CalendarConfig struct {
+	Client         *calendar.Client
+	PollInterval   time.Duration
+	ReminderBefore time.Duration
+}
+
+// NewCalendarSense creates a new calendar sense
+func NewCalendarSense(cfg CalendarConfig, inbox *memory.Inbox) *CalendarSense {
+	if cfg.PollInterval == 0 {
+		cfg.PollInterval = DefaultCalendarPollInterval
+	}
+	if cfg.ReminderBefore == 0 {
+		cfg.ReminderBefore = DefaultMeetingReminderBefore
+	}
+
+	return &CalendarSense{
+		client:         cfg.Client,
+		inbox:          inbox,
+		pollInterval:   cfg.PollInterval,
+		reminderBefore: cfg.ReminderBefore,
+		notifiedEvents: make(map[string]time.Time),
+		stopChan:       make(chan struct{}),
+	}
+}
+
+// Start begins polling the calendar
+func (c *CalendarSense) Start() error {
+	log.Printf("[calendar-sense] Starting with poll interval %v, reminder before %v",
+		c.pollInterval, c.reminderBefore)
+
+	go c.pollLoop()
+	return nil
+}
+
+// Stop stops the calendar polling
+func (c *CalendarSense) Stop() error {
+	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+		return nil
+	}
+	c.stopped = true
+	close(c.stopChan)
+	c.mu.Unlock()
+
+	log.Printf("[calendar-sense] Stopped")
+	return nil
+}
+
+// SetOnError sets an error callback
+func (c *CalendarSense) SetOnError(callback func(err error)) {
+	c.mu.Lock()
+	c.onError = callback
+	c.mu.Unlock()
+}
+
+func (c *CalendarSense) pollLoop() {
+	// Do an initial poll immediately
+	c.poll()
+
+	ticker := time.NewTicker(c.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.stopChan:
+			return
+		case <-ticker.C:
+			c.poll()
+		}
+	}
+}
+
+func (c *CalendarSense) poll() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	c.mu.Lock()
+	c.lastPoll = time.Now()
+	c.mu.Unlock()
+
+	// Check for daily agenda (send once per day, in the morning)
+	c.checkDailyAgenda(ctx)
+
+	// Check for upcoming meetings that need reminders
+	c.checkUpcomingMeetings(ctx)
+
+	// Clean up old notification records (older than 24 hours)
+	c.cleanupNotifications()
+}
+
+func (c *CalendarSense) checkDailyAgenda(ctx context.Context) {
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+
+	c.mu.RLock()
+	lastAgenda := c.lastDailyAgenda
+	c.mu.RUnlock()
+
+	// Send daily agenda between 7 AM and 9 AM, once per day
+	hour := now.Hour()
+	if hour < 7 || hour >= 9 {
+		return
+	}
+
+	// Check if we already sent today
+	if !lastAgenda.IsZero() && lastAgenda.After(today) {
+		return
+	}
+
+	// Get today's events
+	events, err := c.client.GetTodayEvents(ctx)
+	if err != nil {
+		log.Printf("[calendar-sense] Failed to get today's events: %v", err)
+		c.handleError(err)
+		return
+	}
+
+	// Filter to only confirmed events with content
+	var relevantEvents []calendar.Event
+	for _, e := range events {
+		if e.Status != "cancelled" && e.Summary != "" {
+			relevantEvents = append(relevantEvents, e)
+		}
+	}
+
+	if len(relevantEvents) == 0 {
+		log.Printf("[calendar-sense] No events today, skipping daily agenda")
+		c.mu.Lock()
+		c.lastDailyAgenda = now
+		c.mu.Unlock()
+		return
+	}
+
+	// Create daily agenda message
+	agenda := c.formatDailyAgenda(relevantEvents)
+
+	msg := &memory.InboxMessage{
+		ID:        fmt.Sprintf("calendar-agenda-%s", today.Format("2006-01-02")),
+		Type:      "impulse",
+		Subtype:   "daily_agenda",
+		Content:   agenda,
+		Timestamp: now,
+		Status:    "pending",
+		Extra: map[string]any{
+			"source":      "calendar",
+			"event_count": len(relevantEvents),
+			"date":        today.Format("2006-01-02"),
+		},
+	}
+
+	c.inbox.Add(msg)
+
+	c.mu.Lock()
+	c.lastDailyAgenda = now
+	c.mu.Unlock()
+
+	log.Printf("[calendar-sense] Sent daily agenda with %d events", len(relevantEvents))
+}
+
+func (c *CalendarSense) checkUpcomingMeetings(ctx context.Context) {
+	now := time.Now()
+
+	// Look ahead for events starting within reminder window + poll interval
+	// This ensures we don't miss events between polls
+	lookAhead := c.reminderBefore + c.pollInterval
+	events, err := c.client.GetUpcomingEvents(ctx, lookAhead, 10)
+	if err != nil {
+		log.Printf("[calendar-sense] Failed to get upcoming events: %v", err)
+		c.handleError(err)
+		return
+	}
+
+	for _, event := range events {
+		// Skip cancelled events
+		if event.Status == "cancelled" {
+			continue
+		}
+
+		// Skip all-day events for meeting reminders
+		if event.AllDay {
+			continue
+		}
+
+		// Check if event starts within reminder window
+		timeUntil := time.Until(event.Start)
+		if timeUntil > c.reminderBefore || timeUntil < 0 {
+			continue
+		}
+
+		// Check if we already notified for this event
+		notifyKey := fmt.Sprintf("%s-%s", event.ID, event.Start.Format("2006-01-02"))
+		c.mu.RLock()
+		_, alreadyNotified := c.notifiedEvents[notifyKey]
+		c.mu.RUnlock()
+
+		if alreadyNotified {
+			continue
+		}
+
+		// Create meeting reminder
+		c.sendMeetingReminder(event, timeUntil)
+
+		c.mu.Lock()
+		c.notifiedEvents[notifyKey] = now
+		c.mu.Unlock()
+	}
+}
+
+func (c *CalendarSense) sendMeetingReminder(event calendar.Event, timeUntil time.Duration) {
+	// Format reminder content
+	content := fmt.Sprintf("Upcoming meeting in %s: %s", formatDuration(timeUntil), event.Summary)
+	if event.Location != "" {
+		content += fmt.Sprintf("\nLocation: %s", event.Location)
+	}
+	if event.MeetLink != "" {
+		content += fmt.Sprintf("\nVideo call: %s", event.MeetLink)
+	}
+
+	// Build attendee info
+	var attendeeInfo string
+	if len(event.Attendees) > 0 {
+		var names []string
+		for _, a := range event.Attendees {
+			if a.Self {
+				continue // Skip self
+			}
+			name := a.DisplayName
+			if name == "" {
+				name = a.Email
+			}
+			names = append(names, name)
+		}
+		if len(names) > 0 {
+			attendeeInfo = fmt.Sprintf("With: %s", joinMax(names, 5))
+		}
+	}
+	if attendeeInfo != "" {
+		content += "\n" + attendeeInfo
+	}
+
+	// Calculate intensity based on time until event
+	intensity := 0.7
+	if timeUntil < 5*time.Minute {
+		intensity = 0.9 // More urgent if very soon
+	} else if timeUntil < 10*time.Minute {
+		intensity = 0.8
+	}
+
+	msg := &memory.InboxMessage{
+		ID:        fmt.Sprintf("calendar-reminder-%s-%d", event.ID, time.Now().UnixNano()),
+		Type:      "impulse",
+		Subtype:   "meeting_reminder",
+		Content:   content,
+		Timestamp: time.Now(),
+		Status:    "pending",
+		Extra: map[string]any{
+			"source":       "calendar",
+			"event_id":     event.ID,
+			"event_title":  event.Summary,
+			"event_start":  event.Start.Format(time.RFC3339),
+			"event_end":    event.End.Format(time.RFC3339),
+			"time_until":   timeUntil.String(),
+			"has_meet":     event.MeetLink != "",
+			"attendees":    len(event.Attendees),
+			"intensity":    intensity,
+			"meet_link":    event.MeetLink,
+			"location":     event.Location,
+			"description":  event.Description,
+		},
+	}
+
+	c.inbox.Add(msg)
+	log.Printf("[calendar-sense] Sent meeting reminder: %s (in %s)", event.Summary, formatDuration(timeUntil))
+}
+
+func (c *CalendarSense) formatDailyAgenda(events []calendar.Event) string {
+	agenda := fmt.Sprintf("Daily agenda for %s:\n\n", time.Now().Format("Monday, January 2"))
+
+	for i, event := range events {
+		agenda += fmt.Sprintf("%d. %s\n", i+1, event.FormatEventSummary())
+
+		if len(event.Attendees) > 0 {
+			var names []string
+			for _, a := range event.Attendees {
+				if a.Self {
+					continue
+				}
+				name := a.DisplayName
+				if name == "" {
+					name = a.Email
+				}
+				names = append(names, name)
+			}
+			if len(names) > 0 {
+				agenda += fmt.Sprintf("   With: %s\n", joinMax(names, 3))
+			}
+		}
+	}
+
+	return agenda
+}
+
+func (c *CalendarSense) cleanupNotifications() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	cutoff := time.Now().Add(-24 * time.Hour)
+	for key, notifiedAt := range c.notifiedEvents {
+		if notifiedAt.Before(cutoff) {
+			delete(c.notifiedEvents, key)
+		}
+	}
+}
+
+func (c *CalendarSense) handleError(err error) {
+	c.mu.RLock()
+	callback := c.onError
+	c.mu.RUnlock()
+
+	if callback != nil {
+		callback(err)
+	}
+}
+
+// LastPoll returns when the calendar was last polled
+func (c *CalendarSense) LastPoll() time.Time {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.lastPoll
+}
+
+// formatDuration formats a duration in a human-readable way
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return "less than a minute"
+	}
+	if d < 2*time.Minute {
+		return "1 minute"
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%d minutes", int(d.Minutes()))
+	}
+	if d < 2*time.Hour {
+		return "1 hour"
+	}
+	return fmt.Sprintf("%d hours", int(d.Hours()))
+}
+
+// joinMax joins strings with a max count, adding "and X more" if needed
+func joinMax(items []string, max int) string {
+	if len(items) <= max {
+		return joinStrings(items)
+	}
+	return joinStrings(items[:max]) + fmt.Sprintf(" and %d more", len(items)-max)
+}
+
+func joinStrings(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	if len(items) == 1 {
+		return items[0]
+	}
+	if len(items) == 2 {
+		return items[0] + " and " + items[1]
+	}
+	result := ""
+	for i, item := range items {
+		if i == len(items)-1 {
+			result += "and " + item
+		} else {
+			result += item + ", "
+		}
+	}
+	return result
+}

--- a/seed/reflexes/calendar-handler.yaml
+++ b/seed/reflexes/calendar-handler.yaml
@@ -1,0 +1,21 @@
+name: calendar-handler
+description: Handle calendar queries using Ollama classification
+priority: 8
+trigger:
+  source: inbox
+  classifier: ollama
+  model: qwen2.5:7b
+  intents:
+    - calendar_today
+    - calendar_upcoming
+    - calendar_query
+    - calendar_free
+    - not_calendar
+pipeline:
+  - action: gate
+    condition: "{{.intent}} == not_calendar"
+    stop: true
+  - action: calendar_dispatch
+    output: response
+  - action: reply
+    message: "{{.response}}"


### PR DESCRIPTION
- Add calendar client with service account JWT authentication
- Add calendar sense for polling upcoming events and daily agenda
- Add MCP tools: calendar_today, calendar_upcoming, calendar_list_events,
  calendar_free_busy, calendar_get_event, calendar_create_event
- Add calendar reflex with Ollama classification
- Wire integration into main.go with optional startup
- Update .env.example with calendar configuration

Both executive and reflex layers can now access calendar data.
The calendar sense sends meeting reminders 15 minutes before events
and daily agenda summaries in the morning.