### PR TITLE
build: make build.sh cross-platform (macOS + Linux)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,19 @@
 #!/bin/sh
-cd ~/src/bud2
-export CGO_CFLAGS="-Wno-deprecated-declarations"
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
+mkdir -p bin
+
+# Suppress deprecated-declaration warnings from macOS SDK headers
+case "$(uname -s)" in
+  Darwin) export CGO_CFLAGS="-Wno-deprecated-declarations" ;;
+esac
+
 go build -o bin/bud ./cmd/bud
-codesign --sign "bud-dev" --force --deep bin/bud
 go build -o bin/efficient-notion-mcp ./cmd/efficient-notion-mcp
-cd -
+
+# Codesign on macOS if the signing identity exists
+if [ "$(uname -s)" = "Darwin" ] && security find-identity -v -p codesigning 2>/dev/null | grep -q bud-dev; then
+  codesign --sign "bud-dev" --force --deep bin/bud
+fi


### PR DESCRIPTION
## Summary

- Derives repo directory from the script's own location instead of hardcoding `~/src/bud2`
- Gates `CGO_CFLAGS` and `codesign` on macOS — both are silently skipped on Linux
- Adds `set -e` so a failed `go build` actually stops the script
- Adds `mkdir -p bin` to ensure the output directory exists

Tested: builds both `bud` and `efficient-notion-mcp` cleanly on Linux (WSL2).

## Test plan

- [ ] Run `./scripts/build.sh` on macOS — should produce same binaries as before, codesign if `bud-dev` identity exists
- [ ] Run `./scripts/build.sh` on Linux — should build both binaries, skip codesign silently
- [ ] Verify `set -e` causes the script to abort if `go build` fails (e.g., introduce a syntax error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)