### PR TITLE
disable prediction_review impulse

### DIFF
--- a/internal/senses/calendar.go
+++ b/internal/senses/calendar.go
@@ -161,8 +161,8 @@ func (c *CalendarSense) poll() {
 	// Check for daily agenda (send once per day, in the morning)
 	c.checkDailyAgenda(ctx)
 
-	// Check for prediction review impulse (send once per day at 14:00)
-	c.checkPredictionReview()
+	// Disabled: prediction review impulse — will be recreated as a scheduled extension
+	// c.checkPredictionReview()
 
 	// Check for upcoming meetings that need reminders
 	c.checkUpcomingMeetings(ctx)


### PR DESCRIPTION
## Summary
- Commented out `checkPredictionReview()` call in calendar sense polling
- No prediction tasks or tags exist in Things, so this fires daily with nothing to review
- Will be recreated as a scheduled extension once the extensibility framework supports schedule triggers

## Test plan
- [ ] Verify build passes
- [ ] Confirm no prediction_review impulse fires at 14:00

🤖 Generated with [Claude Code](https://claude.com/claude-code)